### PR TITLE
Fix PHP requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "source": "https://github.com/christianbarkowsky/contao-extended-checkbox"
   },
   "require":{
-    "php": "7.4 || ^8.0",
+    "php": "^7.4 || ^8.0",
     "contao/core-bundle": "~4.4"
   },
   "replace": {


### PR DESCRIPTION
Currently this package cannot be installed in version `1.2.4` under PHP 7.4.x because the `composer.json` requires an exact version of PHP, i.e. `7.4` instead of `^7.4`. This PR fixes the requirement.