### PR TITLE
Fix issue with missing form row classes

### DIFF
--- a/src/Form/FormCheckBoxExtended.php
+++ b/src/Form/FormCheckBoxExtended.php
@@ -51,6 +51,7 @@ class FormCheckBoxExtended extends Widget
      * @var string
      */
     protected $strPrefix = 'widget widget-checkbox widget-extended-checkbox';
+    protected $prefix = 'widget widget-checkbox widget-extended-checkbox';
 
     /**
      * @var array
@@ -94,6 +95,11 @@ class FormCheckBoxExtended extends Widget
 
             case 'mandatory':
                 $this->arrConfiguration['mandatory'] = $varValue ? true : false;
+                break;
+
+            case 'prefix':
+                $this->prefix = $varValue;
+                $this->strPrefix = $varValue;
                 break;
 
             default:


### PR DESCRIPTION
This PR fix the issue that there are no form row classes outputted in frontend. 

The source of this issue is the implementation of the widget-templates in twig. The extend-function works different here and do not use the widget-class for the $this variables in the extended php templates anymore. 

This PR introduces an additional variable for the prefix with the correct variable name as used in the form row template. The better option would be the usage of html5-templates, since twig is obviously not correctly supported for widgets at this time, but that would mean a BC break. Another option would be not extending the form_row template. If you prefer my other options or find a different solution, don't hesitate to close this PR :)